### PR TITLE
drop support for NodeJS v6 and not lts versions up to v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ language: node_js
 
 node_js:
   - '12'
-  - '11'
   - '10'
-  - '9'
   - '8'
-  - '7'
-  - '6'
 
 branches:
  except:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "travis-deploy-once": "^5.0.11"
   },
   "engines": {
-    "node": ">=6.10.0"
+    "node": ">=8.0.0"
   },
   "babel": {
     "presets": [
@@ -53,7 +53,7 @@
         "@babel/preset-env",
         {
           "targets": {
-            "node": "6.10"
+            "node": "8.0.0"
           },
           "useBuiltIns": false,
           "exclude": [

--- a/package.json
+++ b/package.json
@@ -69,6 +69,14 @@
       "preset": "angular",
       "releaseRules": [
         {
+          "breaking": true,
+          "release": "major"
+        },
+        {
+          "revert": true,
+          "release": "patch"
+        },
+        {
           "type": "feat",
           "release": "minor"
         },
@@ -89,13 +97,7 @@
           "type": "build",
           "release": "patch"
         }
-      ],
-      "parserOpts": {
-        "noteKeywords": [
-          "BREAKING CHANGE",
-          "BREAKING CHANGES"
-        ]
-      }
+      ]
     }
   },
   "husky": {


### PR DESCRIPTION
NodeJS v6, v7, v9 and v11 not officially supported