### PR TITLE
feat: add typescript declarations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ typings/
 dist
 .idea/
 .vscode/
+index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+export = EError
+
+declare class EError extends Error {
+  [prop: string]: unknown;
+
+  public combine(fields: Record<string, unknown>): EError
+  public wrap<TError extends Partial<Error>>(error: TError): TError & { [prop: string]: unknown }
+
+  public static wrap<TError extends Partial<Error>>(error: TError, fields: Record<string, unknown>): TError & { [prop: string]: unknown }
+
+  public static prepare(baseClass: EErrorClass, fields: Record<string, unknown>): EErrorClass
+  public static prepare(fields: Record<string, unknown>): EErrorClass
+}
+
+declare interface EErrorClass {
+  new (message?: string): EError;
+}


### PR DESCRIPTION
Due to usage of unknown type it may introduce breaking changes in legacy typescript projects with own typings.

Closes #38.